### PR TITLE
Support for custom config files with optional start argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ In default Simmetrica connects to Redis on `127.0.0.1:6379` with database `0`.
 
 Now, you can see your shiny dashboard with pointing your browser to `http://127.0.0.1:5000/`.
 
+A full list of usage options can be displayed with the `--help` flag
+
+     ➜  simmetrica git:(master) ✗ python app.py --help
+
 #####Configuring dashboard blocks
 
 Dashboard is configured with `config.yml` file, this file have a yaml list called `graphs`. Graphs widgets rendered with lovely [rickshaw](https://github.com/shutterstock/rickshaw) (HTML5 + SVG and d3.js) library.
@@ -160,6 +164,10 @@ Dashboard is configured with `config.yml` file, this file have a yaml list calle
             - events
         - graph definition
             - events
+
+Optionally a custom config file can be specified with the `--config` flag
+
+    ➜  simmetrica git:(master) ✗ python app.py --config myConfig.yml
 
 ##### Explanation of configuration parameters
 

--- a/app.py
+++ b/app.py
@@ -6,10 +6,17 @@ import yaml
 import time
 import re
 import os
+import argparse
+ 
 from collections import OrderedDict
 
 from flask import Flask, Response, request, render_template
 from simmetrica import Simmetrica
+
+parser = argparse.ArgumentParser(description='Start Simmetrica web application')
+parser.add_argument('-c', '--config', dest='configFile', default='config.yml',
+                   help='Run with the specified config file (default: config.yml)')
+args = parser.parse_args()
 
 app = Flask(__name__)
 simmetrica = Simmetrica(
@@ -38,7 +45,7 @@ def query(event, start, end):
 
 @app.route('/graph')
 def graph():
-    stream = file('config.yml')
+    stream = file(args.configFile)
     config = yaml.load(stream)
     result = []
     now = simmetrica.get_current_timestamp()


### PR DESCRIPTION
Being able to specify a custom config file is really useful if you don't want to edit the original config.yml file. This is a specially useful if simmetrica is used as a git submodule to other projects.

Example: `./app.py --config myConfig.yml`
